### PR TITLE
WQP-1654  Updated 3.8 Dockerfile to use python image version: 3.8.9-s…

### DIFF
--- a/3.8/Dockerfile
+++ b/3.8/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8.8-slim-buster
+FROM python:3.8.9-slim-buster
 
 RUN apt-get update && apt-get upgrade -y
 


### PR DESCRIPTION
…lim-buster

   Looks like 3.7 is already on latest: 3.7.10-slim-buster`